### PR TITLE
Update FlowerPotBlock.java.patch

### DIFF
--- a/patches/minecraft/net/minecraft/block/FlowerPotBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/FlowerPotBlock.java.patch
@@ -72,6 +72,9 @@
 +   private final java.util.function.Supplier<FlowerPotBlock> emptyPot;
 +   private final java.util.function.Supplier<? extends Block> flowerDelegate;
 +
++   public Map<net.minecraft.util.ResourceLocation, java.util.function.Supplier<? extends Block>> getFullPots() {
++       return fullPots;
++   }
 +   public FlowerPotBlock getEmptyPot() {
 +       return emptyPot == null ? this : emptyPot.get();
 +   }


### PR DESCRIPTION
This should make it easier to make modded FlowerPotBlocks, such as ones that have blockstates.

Some mods have custom FlowerPotBlocks which do more than have new flower types, such as mine, which also has a blockstate property for its color. The item form of the flowers have an nbt tag which controls the color as well, but with the way that FlowerPotBlock is currently implemented, it can not be extended and have the same functionality, because of line 67 which requires access of the fullPots field. 

In order to make custom FlowerPotBlock extensions easier to implement, we can simply add a public getter that returns the private fullPots field.